### PR TITLE
Syntax Change.ts

### DIFF
--- a/particle-auth/src/provider/connection.ts
+++ b/particle-auth/src/provider/connection.ts
@@ -3,7 +3,7 @@ import type { ConnectionOptions, RequestArguments } from './types';
 
 const instance = axios.create({
     baseURL: 'https://rpc.particle.network',
-    timeout: 30_000, // 30 secs
+    timeout: 30000, // 30 secs 
 });
 
 async function request(path: string, args: RequestArguments, config: ConnectionOptions) {


### PR DESCRIPTION
Numeric separators (_) are a feature introduced in ECMAScript 2021 (ES12) that allows developers to make numerical literals more readable by creating a visual separation between groups of digits. However, it seems that the toolchain used by some React Native project's build process (the JavaScript engine or the bundler, such as Metro) does not recognize or properly handle this syntax feature, leading to syntax errors